### PR TITLE
fix: `SafeTooltip` optional wrapper

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,18 @@ const preview: Preview = {
             handlers: restHandlers,
         },
     },
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    width: '600px',
+                    margin: '3em',
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
 }
 
 export default preview

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ import Mapping from './Components/Mapping'
 import Paper from '@mui/material/Paper'
 import SafeTooltip from './Components/SafeTooltip'
 import UploadFilePage from './Components/upload/UploadFilePage'
-import Tooltip from "@mui/material/Tooltip";
+import Tooltip from '@mui/material/Tooltip'
 
 export const pathMatches = (path: string, pathname: string) =>
     matchPath({ path: path, end: true }, pathname) !== null

--- a/src/Components/CardActionBar.tsx
+++ b/src/Components/CardActionBar.tsx
@@ -175,7 +175,10 @@ export default function CardActionBar(props: CardActionBarProps) {
                                     props.setEditing!(false)
                             }}
                         >
-                            <ICONS.SAVE {...iconProps} color={theme.palette.success.main} />
+                            <ICONS.SAVE
+                                {...iconProps}
+                                color={theme.palette.success.main}
+                            />
                         </IconButton>
                     </SafeTooltip>
                     {props.onUndo && (
@@ -210,7 +213,10 @@ export default function CardActionBar(props: CardActionBarProps) {
                                     props.setEditing!(false)
                             }}
                         >
-                            <MdClose {...iconProps} color={theme.palette.error.main} />
+                            <MdClose
+                                {...iconProps}
+                                color={theme.palette.error.main}
+                            />
                         </IconButton>
                     </SafeTooltip>
                 </>

--- a/src/Components/Mapping.tsx
+++ b/src/Components/Mapping.tsx
@@ -456,6 +456,7 @@ function MappingTable({
                                     <TableCell key={i}>
                                         <SafeTooltip
                                             title={`You do not have permission to edit '${mappingResource.name}'`}
+                                            forceWrap={true}
                                         >
                                             <Typography>
                                                 {map[key]?.column_type.name ??
@@ -520,6 +521,7 @@ function MappingTable({
                                         <TableCell key={i}>
                                             <SafeTooltip
                                                 title={`You do not have permission to edit '${mappingResource.name}'`}
+                                                forceWrap={true}
                                             >
                                                 {['int', 'float'].includes(
                                                     map[key]?.column_type
@@ -688,6 +690,7 @@ function MappingTable({
                                         <TableCell key={i}>
                                             <SafeTooltip
                                                 title={`You do not have permission to edit '${mappingResource.name}'`}
+                                                forceWrap={true}
                                             >
                                                 <Typography>{key}</Typography>
                                             </SafeTooltip>
@@ -698,6 +701,7 @@ function MappingTable({
                                         <TableCell key={i}>
                                             <SafeTooltip
                                                 title={`Only recognised columns can be renamed`}
+                                                forceWrap={true}
                                             >
                                                 <Typography>{key}</Typography>
                                             </SafeTooltip>
@@ -708,6 +712,7 @@ function MappingTable({
                                         <TableCell key={i}>
                                             <SafeTooltip
                                                 title={`Required columns cannot be renamed`}
+                                                forceWrap={true}
                                             >
                                                 <Typography>
                                                     {getName(map[key])}
@@ -1018,7 +1023,10 @@ function MappingManager({
                 ) : (
                     <>
                         <Stack direction="row" alignItems="center" spacing={1}>
-                            <SafeTooltip title="Only mappings that are applicable to this file will be available.">
+                            <SafeTooltip
+                                title="Only mappings that are applicable to this file will be available."
+                                forceWrap={true}
+                            >
                                 <Typography>Mapping:</Typography>
                             </SafeTooltip>
                             <Select

--- a/src/Components/SafeTooltip.tsx
+++ b/src/Components/SafeTooltip.tsx
@@ -2,9 +2,34 @@ import Tooltip, { TooltipProps } from '@mui/material/Tooltip'
 import React, { AriaRole, forwardRef } from 'react'
 import { has } from './misc'
 
-export type SafeTooltipProps = TooltipProps & { disabledRole?: AriaRole }
+export type SafeTooltipProps = TooltipProps & {
+    disabledRole?: AriaRole
+    forceWrap?: boolean
+}
 
 /**
+ * ## Usage
+ * SafeTooltip is a wrapper around the MUI Tooltip component that ensures that the tooltip
+ * will show up even if the child is disabled.
+ * Elements that will _never_ be disabled can simply use the MUI Tooltip component.
+ *
+ * The SafeTooltip component can have difficulty with non-interactive children.
+ * In the disabled condition, this is solved by wrapping the child in a `span`.
+ * In the enabled condition, you can solve this by setting `forceWrap` to `true`.
+ *
+ * So while you might call a button like this:
+ * ```tsx
+ * <SafeTooltip title="This is a button"><Button>Click me</Button></SafeTooltip>
+ * ```
+ * You might call a non-interactive element like this:
+ * ```tsx
+ * <SafeTooltip title="This is a paragraph" forceWrap={true}><p>Some text</p></SafeTooltip>
+ * ```
+ *
+ * In the former case, the child will inherit the `aria-label` from the tooltip.
+ * In the latter case, the child will be wrapped in a `span` and the `aria-label` will be added to that `span` wrapper.
+ *
+ * ## Background
  * The `Tooltip` component from MUI has a difficult history with disabled children.
  * If you have a disabled child, the tooltip will not show up.
  * The common solution is to wrap the child in a `span`, but if you do so, the tooltip will
@@ -15,7 +40,7 @@ export type SafeTooltipProps = TooltipProps & { disabledRole?: AriaRole }
  * if it is disabled, but will otherwise just return the child.
  */
 const SafeTooltip = forwardRef(function SafeTooltip(
-    { children, disabledRole, ...props }: SafeTooltipProps,
+    { children, disabledRole, forceWrap, ...props }: SafeTooltipProps,
     ref,
 ) {
     if (
@@ -41,10 +66,17 @@ const SafeTooltip = forwardRef(function SafeTooltip(
             </Tooltip>
         )
     }
-    // Wrap in a span to avoid warnings about Expected an element that can hold a ref.
+    // Wrap in a fragment to avoid warnings about Expected an element that can hold a ref.
+    if (forceWrap)
+        return (
+            <Tooltip {...props} ref={ref}>
+                <span>{children}</span>
+            </Tooltip>
+        )
+    // Allow the child to stand on its own.
     return (
         <Tooltip {...props} ref={ref}>
-            <span>{children}</span>
+            {children}
         </Tooltip>
     )
 })

--- a/src/Components/SnackbarMessengerContext.tsx
+++ b/src/Components/SnackbarMessengerContext.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import Snackbar, { SnackbarProps } from '@mui/material/Snackbar'
 import { useImmer } from 'use-immer'
-import Alert, {AlertProps} from '@mui/material/Alert'
+import Alert, { AlertProps } from '@mui/material/Alert'
 import ListItem from '@mui/material/ListItem'
 import List from '@mui/material/List'
 

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -52,7 +52,7 @@ import { Theme } from '@mui/material/styles'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import Accordion from '@mui/material/Accordion'
 import AccordionDetails from '@mui/material/AccordionDetails'
-import {MdExpandMore} from "react-icons/md";
+import { MdExpandMore } from 'react-icons/md'
 
 type SchemaValidationSummary = {
     detail: SchemaValidation
@@ -301,8 +301,8 @@ export function SchemaValidationList() {
     else if (query.data.length === 0)
         body = !user?.token ? (
             <p>
-                <Button onClick={() => setLoginFormOpen(true)}>Log in</Button>&nbsp;
-                to see your dashboard.
+                <Button onClick={() => setLoginFormOpen(true)}>Log in</Button>
+                &nbsp; to see your dashboard.
             </p>
         ) : (
             <p>

--- a/src/test/Mapping.test.tsx
+++ b/src/test/Mapping.test.tsx
@@ -114,7 +114,7 @@ it('renders', async () => {
     expect(initial_data[1]).toBeInTheDocument()
     await user.hover(initial_data[1])
     screen.getAllByLabelText(/You do not have permission/)
-    expect(initial_data[1].firstElementChild?.nodeName).toBe('P')
+    expect(initial_data[1].firstElementChild?.nodeName).toBe('SPAN')
 
     // Check we can load a mapping
     const load_mapping = screen.getByTestId('load-mapping-select')
@@ -173,7 +173,7 @@ it('renders', async () => {
             .nextElementSibling!,
         'td',
     )
-    expect(renames[1].firstElementChild!.nodeName).toBe('P')
+    expect(renames[1].firstElementChild!.nodeName).toBe('SPAN')
 
     // Check we can rename columns
     const rename = getByDisplayValue('textbox', /SampleNumber/)!

--- a/src/test/ResourceCard.test.tsx
+++ b/src/test/ResourceCard.test.tsx
@@ -3,7 +3,7 @@
 // // of Oxford, and the 'Galv' Developers. All rights reserved.
 
 import { LOOKUP_KEYS } from '../constants'
-import React from 'react'
+import React, { act } from 'react'
 import {
     cleanup,
     render,
@@ -17,7 +17,6 @@ import { MemoryRouter } from 'react-router-dom'
 import FetchResourceContextProvider from '../Components/FetchResourceContext'
 import { Cell } from '@galv/galv'
 import SelectionManagementContextProvider from '../Components/SelectionManagementContext'
-import { act } from 'react-dom/test-utils'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import axios from 'axios'


### PR DESCRIPTION
`SafeTooltip` now has an option to force wrapping of enabled elements in `span` tags. This enables non-interactive children (e.g. `Typography`) to be tooltipped with `forceWrap={true}`, while allowing interactive elements to inherit `aria-*` tags from the tooltip as per MUI's `Tooltip` component.